### PR TITLE
Clarify location to run make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To run this script you will need to install [jq](https://stedolan.github.io/jq/d
 - Ubuntu / Debian `apt-get install jq`
 
 ### Install
+
+Inside the project directory run
 ```sh
 make install 
 ```


### PR DESCRIPTION
## Context ##

The `$ make install` command should be run inside the project directory. I think this line might confuse some users who are unfamilar with the Makefile concept. This PR simply adds a clarifying comment. 